### PR TITLE
Notificação ao usuário da reabertura do seu chamado.

### DIFF
--- a/app/Http/Controllers/Painel/ChamadoController.php
+++ b/app/Http/Controllers/Painel/ChamadoController.php
@@ -615,6 +615,8 @@ class ChamadoController extends Controller
         // Atualiza o status para "Reaberto" 
         $chamado->status_chamado_id = StatusChamado::REABERTO;
         $chamado->chamado_resolvido = null; // Remove a data de resolução
+        $chamado->chamado_atendimento = null;
+        $chamado->chamado_abertura = now();
         $chamado->save();
 
         // Adiciona comentário da reabertura
@@ -625,7 +627,14 @@ class ChamadoController extends Controller
             'usuario_id' => Auth::user()->usuario_id
         ]);
 
-        return redirect()->back()->with('success', 'Chamado reaberto com sucesso! O departamento responsável foi notificado.');
+        $posicaoFila = Chamado::where('departamento_id', $chamado->departamento_id) 
+            ->whereIn('status_chamado_id', [1, 2, 6, 8]) 
+            ->count();
+
+        return redirect()->route('painel.dashboard')
+            ->with('success', 'Chamado reaberto com sucesso!')
+            ->with('chamado_id', $chamado->chamado_id)
+            ->with('posicao_fila', $posicaoFila);
     }
 
     /**

--- a/resources/views/painel/dashboard/index.blade.php
+++ b/resources/views/painel/dashboard/index.blade.php
@@ -669,6 +669,34 @@ $(document).ready(function() {
     });
 @endif
 
+@if(session('chamado_id') && session('posicao_fila'))
+    // Verificamos se há a sessão 'success' e se ela contém a palavra 'Reaberto' para ajustar o título.
+    let title = '@if(str_contains(session('success'), 'reaberto')) Chamado Reaberto com Sucesso! @else Chamado Criado com Sucesso! @endif';
+    
+    // Isso é uma forma simples. Se sua mensagem de sucesso for padronizada, pode ser mais fácil.
+
+    Swal.fire({
+        title: title, // Título dinâmico
+        html: `
+            <div style="text-align: left; padding: 20px;">
+                <p><strong>Seu chamado foi adicionado à fila de espera</strong></p>
+                <p>Todas as atualizações sobre o andamento do seu chamado serão registradas diretamente no chamado no SAC.</p>
+                <hr>
+                <p><strong>Sua posição na fila de atendimento:</strong> 
+                    <span style="color: #007bff; font-size: 18px; font-weight: bold;">{{ session('posicao_fila') }}</span>
+                </p>
+                <p><strong>Número do chamado:</strong> #{{ session('chamado_id') }}</p>
+            </div>
+        `,
+        icon: 'success',
+        confirmButtonText: 'Entendi',
+        confirmButtonColor: '#28a745',
+        allowOutsideClick: false,
+        allowEscapeKey: false,
+        width: '500px'
+    });
+@endif
+
 @if(session('avaliacoes_pendentes'))
     Swal.fire({
         title: 'Avaliações Pendentes!',


### PR DESCRIPTION
Além de ter sido adicionada a notificação, corrigi a função reabrirChamado, pois era necessário que ela apagasse a data do atendimento anterior e a atualizasse a data de abertura para entrar corretamente na fila de chamados.